### PR TITLE
Feature/remove jq requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ AWS_PROFILE=<profile> python3 asg-az-update.py --services=<asg-prefix> --blackli
 
 ### What is my AZ?
 
-Run the following got check the mapping:
+Run the following to check the mapping:
 
 `AWS_PROFILE=<aws-profile> ./aws-az-map.sh us-east-1`

--- a/aws-az-map.sh
+++ b/aws-az-map.sh
@@ -5,4 +5,4 @@ if [ $# != 1 ]; then
     exit 1
 fi
 
-aws ec2 describe-availability-zones --region "$1" --query 'AvailabilityZones[].[ZoneId, ZoneName]' --output text | sed 's/\t/=/'
+aws ec2 describe-availability-zones --region "$1" --query 'AvailabilityZones[].[ZoneId, ZoneName]' --output text

--- a/aws-az-map.sh
+++ b/aws-az-map.sh
@@ -5,4 +5,4 @@ if [ $# != 1 ]; then
     exit 1
 fi
 
-aws ec2 describe-availability-zones --region "$1" | jq -r '.AvailabilityZones[] | .ZoneId + "=" + .ZoneName'
+aws ec2 describe-availability-zones --region "$1" --query 'AvailabilityZones[].[ZoneId, ZoneName]' --output text | sed 's/\t/=/'


### PR DESCRIPTION
Removes the requirement for jq; output remains unchanged

Example with JQ:
```
$ aws ec2 describe-availability-zones --region "us-east-1" | jq -r '.AvailabilityZones[] | .ZoneId + "=" + .ZoneName'
use1-az2=us-east-1a
use1-az4=us-east-1b
use1-az6=us-east-1c
use1-az1=us-east-1d
use1-az3=us-east-1e
use1-az5=us-east-1f
```

Using jmespath with sed:
```
$ aws ec2 describe-availability-zones --region "us-east-1" --query 'AvailabilityZones[].[ZoneId, ZoneName]' --output text | sed 's/\t/=/'
use1-az2=us-east-1a
use1-az4=us-east-1b
use1-az6=us-east-1c
use1-az1=us-east-1d
use1-az3=us-east-1e
use1-az5=us-east-1f
```

Personally I prefer it without the sed as seen below, but I didn't want to change your output without your approval:
```
$ aws ec2 describe-availability-zones --region "us-east-1" --query 'AvailabilityZones[].[ZoneId, ZoneName]' --output text
use1-az2        us-east-1a
use1-az4        us-east-1b
use1-az6        us-east-1c
use1-az1        us-east-1d
use1-az3        us-east-1e
use1-az5        us-east-1f
```